### PR TITLE
Stuff

### DIFF
--- a/app/assets/javascripts/battletype.js
+++ b/app/assets/javascripts/battletype.js
@@ -23,6 +23,9 @@
       Dockyard.registerTemplate("small", document.getElementById("small_ship_template"));
       Dockyard.registerTemplate("medium", document.getElementById("medium_ship_template"));
       Dockyard.registerTemplate("large", document.getElementById("large_ship_template"));
+      Dockyard.registerTemplate("mothership", document.getElementById("mothership_template"));
+      
+      this.mothership = Dockyard.launchMothership(this.combatZone);
       
       this._eventsRelay.addEventListener("entry", function (e) { this.transmitEntry(e.detail); }.bind(this), false);
       this._eventsRelay.addEventListener("switchMode", function (e) { this.switchMode(e.detail); }.bind(this), false);

--- a/app/assets/javascripts/battletype/dockyard.js
+++ b/app/assets/javascripts/battletype/dockyard.js
@@ -1,5 +1,6 @@
-/* globals Ship */
+/* globals Ship, Mothership */
 //= require battletype/ship
+//= require battletype/mothership
 
 (function () {
   this.Dockyard = {
@@ -11,6 +12,10 @@
       newShip.positionY = combatZone.randomFreeVerticalSlot;
       newShip.appendTo(combatZone);
       console.log(newShip);
+    },
+    launchMothership: function (combatZone) {
+      var mothership = Mothership.build(this._templates["mothership"]);
+      mothership.appendTo(combatZone);
     },
     registerTemplate: function (name, element) {
       this._templates[name] = element;

--- a/app/assets/javascripts/battletype/mothership.js
+++ b/app/assets/javascripts/battletype/mothership.js
@@ -1,0 +1,8 @@
+(function () {
+  this.Mothership = {
+    build: function (template) {
+      var ship = Object.defineProperties($(template).clone(), {});
+      return ship;
+    }
+  };
+}).call(this);

--- a/app/assets/stylesheets/_mothership.scss
+++ b/app/assets/stylesheets/_mothership.scss
@@ -1,4 +1,4 @@
-#mothership {
+.mothership {
   text-align: center;
   position: absolute;
   display: block;
@@ -9,7 +9,8 @@
     background: $word_label;
     border-radius: 4px;
     color: $white;
-    display: inline-block;
+//    display: inline-block;
+    display: none; // Pas pour l'instant
     font-family: Consolas, monaco, monospace;
     font-size: .8em;
     margin: 0;

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -1,6 +1,6 @@
-// #dockyard {
-//   display: none;
-// }
+#dockyard {
+ display: none;
+}
 
 #stdin {
   color: $white;

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -63,8 +63,8 @@
 </div>
 
 <div id="dockyard">
-  <div id="mothership">
-    <p class="word">hahaha you stupid bitch!</p>
+  <div id="mothership_template" class="mothership">
+    <p class="word"></p>
     <div class="ship">
       <%= render "games/ships/svg/mothership" %>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,6 +11,8 @@ Rails.application.configure do
 
   # Show full error reports.
   config.consider_all_requests_local = true
+  
+  config.action_cable.disable_request_forgery_protection = true
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?


### PR DESCRIPTION
- Plus besoin des vaisseaux d'exemple
- L'affichage du vaisseau-mère est fait par le client JS
- Pas de mot au-dessus du vaisseau-mère (pour l'instant)
